### PR TITLE
Dev 4.1.6

### DIFF
--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -960,10 +960,9 @@ begin
 
   if LegendaryIndex = -1 then
     Exit;
-    
+
   if not Supports(LegendaryMods.Elements[LegendaryIndex], IwbContainerElementRef, ModBase) then
     Exit;
-  
 
   Result := ModBase.Elements[1].LinksTo;
 end;
@@ -5737,6 +5736,72 @@ end;
       wbEmpty(XLKT, 'Linked Ref Transient'),
       wbXRGD,
       wbFormIDCk(XLYR, 'Layer', [LAYR]),
+      wbStruct(XRLL, 'Lighting', [
+        wbByteColors('Ambient Color'),
+        wbByteColors('Directional Color'),
+        wbByteColors('Fog Color Near'),
+        wbFloat('Fog Near'),
+        wbFloat('Fog Far'),
+        wbInteger('Directional Rotation XY', itS32),
+        wbInteger('Directional Rotation Z', itS32),
+        wbFloat('Directional Fade'),
+        wbFloat('Fog Clip Distance'),
+        wbFloat('Fog Power'),
+        wbAmbientColors('Ambient Colors'),
+        wbByteColors('Fog Color Far'),
+        wbFloat('Fog Max'),
+        wbFloat('Light Fade Begin'),
+        wbFloat('Light Fade End'),
+        wbInteger('Inherits', itU32, wbFlags([
+          {0x00000001} 'Ambient Color',
+          {0x00000002} 'Directional Color',
+          {0x00000004} 'Fog Color',
+          {0x00000008} 'Fog Near',
+          {0x00000010} 'Fog Far',
+          {0x00000020} 'Directional Rotation',
+          {0x00000040} 'Directional Fade',
+          {0x00000080} 'Clip Distance',
+          {0x00000100} 'Fog Power',
+          {0x00000200} 'Fog Max',
+          {0x00000400} 'Light Fade Distances',
+          {0x00000800} 'Unknown 11',
+          {0x00001000} 'Unknown 12',
+          {0x00002000} 'Unknown 13',
+          {0x00004000} 'Unknown 14',
+          {0x00008000} 'Unknown 15',
+          {0x00010000} 'Unknown 16',
+          {0x00020000} 'Unknown 17',
+          {0x00040000} 'Unknown 18',
+          {0x00080000} 'Unknown 19',
+          {0x00100000} 'Unknown 20',
+          {0x00200000} 'Unknown 21',
+          {0x00400000} 'Unknown 22',
+          {0x00800000} 'Unknown 23',
+          {0x01000000} 'Unknown 24',
+          {0x02000000} 'Unknown 25',
+          {0x04000000} 'Unknown 26',
+          {0x08000000} 'Unknown 27',
+          {0x10000000} 'Unknown 28',
+          {0x20000000} 'Unknown 29',
+          {0x40000000} 'Unknown 30'
+        ])),
+        wbFloat('Near Height Mid'),
+        wbFloat('Near Height Range'),
+        wbByteColors('Fog Color High Near'),
+        wbByteColors('Fog Color High Far'),
+        wbFloat('High Density Scale'),
+        wbFloat('Fog Near Scale'),
+        wbFloat('Fog Far Scale'),
+        wbFloat('Fog High Near Scale'),
+        wbFloat('Fog High Far Scale'),
+        wbFloat('Far Height Mid'),
+        wbFloat('Far Height Range'),
+        wbStruct('Skybox Bounds', [
+            wbVec3('Center'),
+            wbVec3('Radius')
+          ])
+      ], cpNormal, False, nil, 11),
+      wbFormIDCk(XRL2, 'Lighting Template', [LGTM]),
       wbFormIDCk(XMSP, 'Material Swap', [MSWP]),
       wbXLWT,
       wbFormIDCk(XRFG, 'Reference Group', [RFGP]),
@@ -7214,6 +7279,72 @@ begin
     wbEmpty(XLKT, 'Linked Ref Transient'),
     wbFormIDCk(XRFG, 'Reference Group', [RFGP]),
     wbFormIDCk(XLYR, 'Layer', [LAYR]),
+    wbStruct(XRLL, 'Lighting', [
+      wbByteColors('Ambient Color'),
+      wbByteColors('Directional Color'),
+      wbByteColors('Fog Color Near'),
+      wbFloat('Fog Near'),
+      wbFloat('Fog Far'),
+      wbInteger('Directional Rotation XY', itS32),
+      wbInteger('Directional Rotation Z', itS32),
+      wbFloat('Directional Fade'),
+      wbFloat('Fog Clip Distance'),
+      wbFloat('Fog Power'),
+      wbAmbientColors('Ambient Colors'),
+      wbByteColors('Fog Color Far'),
+      wbFloat('Fog Max'),
+      wbFloat('Light Fade Begin'),
+      wbFloat('Light Fade End'),
+      wbInteger('Inherits', itU32, wbFlags([
+        {0x00000001} 'Ambient Color',
+        {0x00000002} 'Directional Color',
+        {0x00000004} 'Fog Color',
+        {0x00000008} 'Fog Near',
+        {0x00000010} 'Fog Far',
+        {0x00000020} 'Directional Rotation',
+        {0x00000040} 'Directional Fade',
+        {0x00000080} 'Clip Distance',
+        {0x00000100} 'Fog Power',
+        {0x00000200} 'Fog Max',
+        {0x00000400} 'Light Fade Distances',
+        {0x00000800} 'Unknown 11',
+        {0x00001000} 'Unknown 12',
+        {0x00002000} 'Unknown 13',
+        {0x00004000} 'Unknown 14',
+        {0x00008000} 'Unknown 15',
+        {0x00010000} 'Unknown 16',
+        {0x00020000} 'Unknown 17',
+        {0x00040000} 'Unknown 18',
+        {0x00080000} 'Unknown 19',
+        {0x00100000} 'Unknown 20',
+        {0x00200000} 'Unknown 21',
+        {0x00400000} 'Unknown 22',
+        {0x00800000} 'Unknown 23',
+        {0x01000000} 'Unknown 24',
+        {0x02000000} 'Unknown 25',
+        {0x04000000} 'Unknown 26',
+        {0x08000000} 'Unknown 27',
+        {0x10000000} 'Unknown 28',
+        {0x20000000} 'Unknown 29',
+        {0x40000000} 'Unknown 30'
+      ])),
+      wbFloat('Near Height Mid'),
+      wbFloat('Near Height Range'),
+      wbByteColors('Fog Color High Near'),
+      wbByteColors('Fog Color High Far'),
+      wbFloat('High Density Scale'),
+      wbFloat('Fog Near Scale'),
+      wbFloat('Fog Far Scale'),
+      wbFloat('Fog High Near Scale'),
+      wbFloat('Fog High Far Scale'),
+      wbFloat('Far Height Mid'),
+      wbFloat('Far Height Range'),
+      wbStruct('Skybox Bounds', [
+          wbVec3('Center'),
+          wbVec3('Radius')
+        ])
+    ], cpNormal, False, nil, 11),
+    wbFormIDCk(XRL2, 'Lighting Template', [LGTM]),
     wbFormIDCk(XMSP, 'Material Swap', [MSWP]),
 
     wbXLWT,
@@ -9834,12 +9965,10 @@ begin
       wbFloat('Fog High Far Scale'),
       wbFloat('Far Height Mid'),
       wbFloat('Far Height Range'),
-      wbFloat('Unknown'),
-      wbFloat('Unknown'),
-      wbFloat('Unknown'),
-      wbFloat('Unknown'),
-      wbFloat('Unknown'),
-      wbFloat('Unknown')
+      wbStruct('Skybox Bounds', [
+          wbVec3('Center'),
+          wbVec3('Radius')
+        ])
     ], cpNormal, False, nil, 11),
 
     wbInteger(CNAM, 'Precombined Object Level XY', itU8),
@@ -10703,6 +10832,7 @@ begin
     ])), [
     wbEDID,
     wbXALG,
+    wbFTAGs,
     wbInteger(FNAM, 'Type', itU8, wbEnum([], [
       Ord('s'), 'Short',
       Ord('l'), 'Long',
@@ -10990,7 +11120,11 @@ begin
       wbString(NAM1, 'Model FileName'),
       wbModelInfo(NAM2)
     ], [], cpNormal, True),
-    wbInteger(VNAM, 'Sound Level', itU32, wbSoundLevelEnum, cpNormal, True)
+    wbInteger(VNAM, 'Sound Level', itU32, wbSoundLevelEnum, cpNormal, True),
+    wbFormID(PSCT, 'Speed Curve Table'),
+    wbFormID(PSSC, 'Seek Strength Curve Table'),
+    wbFloat(PFDX, 'X-Axis Drag'),
+    wbFloat(PFDZ, 'Z-Axis Drag')
   ]);
 
   wbRecord(HAZD, 'Hazard', [
@@ -11741,6 +11875,7 @@ begin
         wbModelInfo(NAM5),
         wbString(ENAM, 'Hit Reaction - Start'),
         wbString(FNAM, 'Hit Reaction - End'),
+        wbUnknown(BPAB),
         wbFormIDCk(BNAM, 'Gore Effects - Dismember Blood Art', [ARTO]),
         wbFormIDCk(INAM, 'Gore Effects - Blood Impact Material Type', [MATT]),
         wbFormIDCk(JNAM, 'On Cripple - Blood Impact Material Type', [MATT]),
@@ -13989,6 +14124,7 @@ begin
       wbLVOT,
       wbLVIV,
       wbLVIG,
+      wbLVIT,
       wbLVLV,
       wbLVOG,
       wbLVLT
@@ -14508,6 +14644,7 @@ begin
     wbDEFL,
     wbPHST,
     wbXALG,
+    wbFTAGs,
     wbStruct(ACBS, 'Configuration', [
       wbInteger('Flags', itU32, wbFlags([
         {0x00000001} 'Female',
@@ -14955,6 +15092,7 @@ begin
   wbRecord(PACK, 'Package', [
     wbEDID,
     wbVMADFragmentedPACK,
+    wbFTAGs,
 
     wbStruct(PKDT, 'Pack Data', [
       wbInteger('General Flags', itU32, wbPKDTFlags),
@@ -15666,6 +15804,7 @@ begin
     wbEDID,
     wbString(DURL, 'Group Name'),
     wbSTCP,
+    wbFTAGs,
     wbFULL,
     wbDESCReq,
     wbSPCT,
@@ -16203,6 +16342,72 @@ begin
     wbInteger(XAMC, 'Ammo Count', itU32),
     wbEmpty(XLKT, 'Linked Ref Transient'),
     wbFormIDCk(XLYR, 'Layer', [LAYR]),
+    wbStruct(XRLL, 'Lighting', [
+      wbByteColors('Ambient Color'),
+      wbByteColors('Directional Color'),
+      wbByteColors('Fog Color Near'),
+      wbFloat('Fog Near'),
+      wbFloat('Fog Far'),
+      wbInteger('Directional Rotation XY', itS32),
+      wbInteger('Directional Rotation Z', itS32),
+      wbFloat('Directional Fade'),
+      wbFloat('Fog Clip Distance'),
+      wbFloat('Fog Power'),
+      wbAmbientColors('Ambient Colors'),
+      wbByteColors('Fog Color Far'),
+      wbFloat('Fog Max'),
+      wbFloat('Light Fade Begin'),
+      wbFloat('Light Fade End'),
+      wbInteger('Inherits', itU32, wbFlags([
+        {0x00000001} 'Ambient Color',
+        {0x00000002} 'Directional Color',
+        {0x00000004} 'Fog Color',
+        {0x00000008} 'Fog Near',
+        {0x00000010} 'Fog Far',
+        {0x00000020} 'Directional Rotation',
+        {0x00000040} 'Directional Fade',
+        {0x00000080} 'Clip Distance',
+        {0x00000100} 'Fog Power',
+        {0x00000200} 'Fog Max',
+        {0x00000400} 'Light Fade Distances',
+        {0x00000800} 'Unknown 11',
+        {0x00001000} 'Unknown 12',
+        {0x00002000} 'Unknown 13',
+        {0x00004000} 'Unknown 14',
+        {0x00008000} 'Unknown 15',
+        {0x00010000} 'Unknown 16',
+        {0x00020000} 'Unknown 17',
+        {0x00040000} 'Unknown 18',
+        {0x00080000} 'Unknown 19',
+        {0x00100000} 'Unknown 20',
+        {0x00200000} 'Unknown 21',
+        {0x00400000} 'Unknown 22',
+        {0x00800000} 'Unknown 23',
+        {0x01000000} 'Unknown 24',
+        {0x02000000} 'Unknown 25',
+        {0x04000000} 'Unknown 26',
+        {0x08000000} 'Unknown 27',
+        {0x10000000} 'Unknown 28',
+        {0x20000000} 'Unknown 29',
+        {0x40000000} 'Unknown 30'
+      ])),
+      wbFloat('Near Height Mid'),
+      wbFloat('Near Height Range'),
+      wbByteColors('Fog Color High Near'),
+      wbByteColors('Fog Color High Far'),
+      wbFloat('High Density Scale'),
+      wbFloat('Fog Near Scale'),
+      wbFloat('Fog Far Scale'),
+      wbFloat('Fog High Near Scale'),
+      wbFloat('Fog High Far Scale'),
+      wbFloat('Far Height Mid'),
+      wbFloat('Far Height Range'),
+      wbStruct('Skybox Bounds', [
+          wbVec3('Center'),
+          wbVec3('Radius')
+        ])
+    ], cpNormal, False, nil, 11),
+    wbFormIDCk(XRL2, 'Lighting Template', [LGTM]),
     wbFormIDCk(XMSP, 'Material Swap', [MSWP]),
     wbXLWT,
     wbFormIDCk(XRFG, 'Reference Group', [RFGP]),
@@ -18101,6 +18306,7 @@ begin
     wbXFLG,
     wbFormID(CNAM, 'Category'),
     wbFormID(DNAM, 'Animation'),
+    wbLString(ACTV, 'Unused'), //Currently does nothing and seems to be something that would show up in the text chat or the cut TTS/STT feature but 76 doesn't have text chat.
     wbKeywords
   ]);
 
@@ -18428,6 +18634,17 @@ begin
     ]),
     wbUnknown(DICO)
   ]);
+
+  wbRecord(PLYT, 'Player Title', [
+    wbEDID,
+    wbXALG,
+    wbLString(ANAM, 'Title'), //Possibly male version
+    wbLString(BNAM), //Possibly female version
+    wbInteger(PTPR, 'Is Prefix', itU8, wbBoolEnum),
+    wbInteger(PTSU, 'Is Suffix', itU8, wbBoolEnum),
+    wbUnknown(PTDS), //Only shows up on ones labeled with DEL so most likely a deleted flag
+    wbCTDAs
+  ]).SetSummaryKey([2]).IncludeFlag(dfSummaryNoName);
 
   wbRecord(WATR, 'Water', [
     wbEDID,
@@ -18757,7 +18974,12 @@ begin
       'Fast',
       'Very Fast'
     ])),
-    wbDAMS
+    wbDAMS,
+    wbRStruct('Telegraph Data', [
+      wbFloat(WTDT, 'Time'),
+      wbFormID(WTDA, 'Visual'),
+      wbFormID(WTDS, 'Sound')
+    ], [])
   ], False, nil, cpNormal, False, nil{wbWEAPAfterLoad});
 
   wbRecord(WTHR, 'Weather',
@@ -19167,10 +19389,11 @@ begin
   wbAddGroupOrder(QMDL); //new in Fallout 76
   wbAddGroupOrder(LOUT); //new in Fallout 76
   wbAddGroupOrder(DIST); //new in Fallout 76
+  wbAddGroupOrder(PLYT);
   wbNexusModsUrl := 'https://www.nexusmods.com/fallout76/mods/30';
   {if wbToolMode = tmLODgen then
     wbNexusModsUrl := '';}
-  wbHEDRVersion := 216.0;
+  wbHEDRVersion := 224.0;
 end;
 
 initialization

--- a/Core/wbDefinitionsSignatures.pas
+++ b/Core/wbDefinitionsSignatures.pas
@@ -217,6 +217,7 @@ const
   BOID : TwbSignature = 'BOID'; { New To Starfield }
   BOLV : TwbSignature = 'BOLV'; { New To Starfield }
   BOOK : TwbSignature = 'BOOK';
+  BPAB : TwbSignature = 'BPAB'; { New To Fallout 76 }
   BPD2 : TwbSignature = 'BPD2'; { New To Starfield }
   BPND : TwbSignature = 'BPND';
   BPNI : TwbSignature = 'BPNI';
@@ -1009,6 +1010,8 @@ const
   PEWI : TwbSignature = 'PEWI'; { New To Fallout 76 0.2.782.0 }
   PEWR : TwbSignature = 'PEWR'; { New To Fallout 76 0.2.782.0 }
   PFAC : TwbSignature = 'PFAC'; { New To Fallout 76 }
+  PFDX : TwbSignature = 'PFDX'; { New To Fallout 76 }
+  PFDZ : TwbSignature = 'PFDZ'; { New To Fallout 76 }
   PFHS : TwbSignature = 'PFHS'; { New To Starfield }
   PFIG : TwbSignature = 'PFIG';
   PFIN : TwbSignature = 'PFIN';
@@ -1048,6 +1051,7 @@ const
   PLRL : TwbSignature = 'PLRL'; { New To Starfield }
   PLVD : TwbSignature = 'PLVD'; { New to Skyrim }
   PLYR : TwbSignature = 'PLYR';
+  PLYT : TwbSignature = 'PLYT';
   PMFT : TwbSignature = 'PMFT'; { New To Fallout 76 }
   PMIS : TwbSignature = 'PMIS';
   PNAM : TwbSignature = 'PNAM';
@@ -1086,13 +1090,18 @@ const
   PRRK : TwbSignature = 'PRRK'; { New To Starfield }
   PRTN : TwbSignature = 'PRTN'; { New To Starfield }
   PRVN : TwbSignature = 'PRVN'; { New To Starfield }
+  PSCT : TwbSignature = 'PSCT'; { New To Fallout 76 }
   PSDC : TwbSignature = 'PSDC'; { New To Starfield }
   PSDF : TwbSignature = 'PSDF'; { New To Starfield }
   PSDT : TwbSignature = 'PSDT';
+  PSSC : TwbSignature = 'PSSC'; { New To Fallout 76 }
   PTCL : TwbSignature = 'PTCL'; { New To Starfield }
   PTD2 : TwbSignature = 'PTD2';
   PTDA : TwbSignature = 'PTDA'; { New to Skyrim }
   PTDT : TwbSignature = 'PTDT';
+  PTDS : TwbSignature = 'PTDS';
+  PTPR : TwbSignature = 'PTPR';
+  PTSU : TwbSignature = 'PTSU';
   PTEX : TwbSignature = 'PTEX';
   PTOP : TwbSignature = 'PTOP'; { New to Fallout 4 }
   PTRN : TwbSignature = 'PTRN'; { New to Fallout 4 }
@@ -1555,6 +1564,9 @@ const
   WSLS : TwbSignature = 'WSLS'; { New To Starfield }
   WSLT : TwbSignature = 'WSLT'; { New To Starfield }
   WSPR : TwbSignature = 'WSPR'; { New To Fallout 76 }
+  WTDA : TwbSignature = 'WTDA'; { New To Fallout 76 }
+  WTDS : TwbSignature = 'WTDS'; { New To Fallout 76 }
+  WTDT : TwbSignature = 'WTDT'; { New To Fallout 76 }
   WTED : TwbSignature = 'WTED'; { New To Starfield }
   WTFG : TwbSignature = 'WTFG'; { New To Fallout 76 }
   WTFM : TwbSignature = 'WTFM'; { New To Starfield }
@@ -1701,6 +1713,8 @@ const
   XRFG : TwbSignature = 'XRFG'; { New To Fallout 4 }
   XRGB : TwbSignature = 'XRGB';
   XRGD : TwbSignature = 'XRGD';
+  XRLL : TwbSignature = 'XRLL'; { New To Fallout 76 }
+  XRL2 : TwbSignature = 'XRL2'; { New To Fallout 76 }
   XRMR : TwbSignature = 'XRMR';
   XRNK : TwbSignature = 'XRNK';
   XRTM : TwbSignature = 'XRTM'; { New To Fallou76. EXTRA_TELEPORTMARKER. 4 bytes }

--- a/Core/wbDefinitionsSignatures.pas
+++ b/Core/wbDefinitionsSignatures.pas
@@ -505,8 +505,13 @@ const
   F0TX : TwbSignature = 'F0TX';
   FACT : TwbSignature = 'FACT';
   FADT : TwbSignature = 'FADT';
+  FCAF : TwbSignature = 'FCAF'; { New To Fallout 76 }
+  FCBM : TwbSignature = 'FCBM'; { New To Fallout 76 }
   FCHT : TwbSignature = 'FCHT'; { New to Skyrim }
+  FCNR : TwbSignature = 'FCNR'; { New To Fallout 76 }
+  FCOR : TwbSignature = 'FCOR'; { New To Fallout 76 }
   FCPL : TwbSignature = 'FCPL'; { New To Fallout 4 }
+  FCRF : TwbSignature = 'FCRF'; { New To Fallout 76 }
   FCTF : TwbSignature = 'FCTF'; { New To Starfield }
   FCTP : TwbSignature = 'FCTP'; { New To Starfield }
   FDDS : TwbSignature = 'FDDS'; { New To Starfield }
@@ -723,6 +728,7 @@ const
   LLRV : TwbSignature = 'LLRV'; { New To Starfield }
   LLSH : TwbSignature = 'LLSH'; { New To Starfield }
   LLVL : TwbSignature = 'LLVL'; { New To Fallout 76 }
+  LMML : TwbSignature = 'LMML'; { New To Fallout 76 }
   LMSW : TwbSignature = 'LMSW'; { New To Starfield }
   LNA2 : TwbSignature = 'LNA2'; { New To Starfield }
   LNAM : TwbSignature = 'LNAM';
@@ -1174,6 +1180,7 @@ const
   QTVR : TwbSignature = 'QTVR'; { New To Fallout 76 }
   QTYP : TwbSignature = 'QTYP'; { New To Starfield }
   QUAL : TwbSignature = 'QUAL'; { New To Skyrim }
+  QUCF : TwbSignature = 'QUCF'; { New To Fallout 76 }
   QUIM : TwbSignature = 'QUIM'; { New To Fallout 76 }
   QUST : TwbSignature = 'QUST';
   RABG : TwbSignature = 'RABG'; { New To Starfield }
@@ -1559,6 +1566,7 @@ const
   WPDT : TwbSignature = 'WPDT';
   WRLD : TwbSignature = 'WRLD';
   WRLO : TwbSignature = 'WRLO'; { New To Starfield }
+  WSAM : TwbSignature = 'WSAM'; { New To Fallout 76 }
   WSED : TwbSignature = 'WSED'; { New To Starfield }
   WSLD : TwbSignature = 'WSLD'; { New To Starfield }
   WSLS : TwbSignature = 'WSLS'; { New To Starfield }


### PR DESCRIPTION
Add XRLL which is reference lighting (same structure as XCLL which is cell lighting) and XRL2 which is reference lighting template (same as Cell LTMP which is cell lighting template) to REFR and all REFR records
Add FTAG Form Tags to GLOB, NPC_, PACK and RACE
Add PSCT, PSSC, PFDX, and PFDZ to PROJ
Add PBAP to BPTD
Add LVIT to LVLI
Add ACTV to EMOT (Currently unused)
Add PLYT Player Title record with subrecords of EDID, XALG, ANAM, BNAM, PTPR, PTSU, PTDS, and conditions.
Add Telegraph Data WTDT, WTDA, and WTDS to WEAP
Update header version to 224.

Updates to allow to work with the PTS as of Feb 2 2025. Version 0.2.1707.0
Add Condition functions for GetIsDisguisedWithKeyword and GetIsPlayerGhoul
Add entry points for Instant Reload Clip On Bash, Mod Attack Damage On Striking Appendage, Apply Spell On Actor When Limb Crippled, Mod Rads to Health Mult, Mod Rads to Radshield Mult, and Mod Weak Body Part Damage Mult
Add what seems to be entry check information for FACT. Has FCNR, FCRF, FCOR, FCBM, CITC, CTDA, and FCAF
Add FULL to TXST
Add DESC to EXPL
Add KNAM (Keyword) to OTFT
Add Unknown data at the end of QUST DATA
Add QUST QUCF
Add LOUT LMML
WEAP WSAM is Sneak Attack Multiplier

Add additional condition functions and weapon property types
Add record flags 2 and 9 to BOOK ADDN OTFT and PLYT
Add NULL as a valid record type for ALDN display name and RDES
Add AFOH to default objects