### PR TITLE
Fix #1369 FileByLoadOrderFileID now accepts string argument. 

### DIFF
--- a/xEdit/JvI/xejviScriptHost.pas
+++ b/xEdit/JvI/xejviScriptHost.pas
@@ -182,10 +182,9 @@ begin
       JvInterpreterError(ieDirectInvalidArgument, 0); // or  ieNotEnoughParams, ieIncompatibleTypes or others.
   end
   else if SameText(Identifier, 'FileByLoadOrderFileID') then begin
-    if (Args.Count = 1) and VarIsNumeric(Args.Values[0]) and (Args.Values[0] < Length(Files)) then begin
-      var aLoadOrderFileID := TwbFileID.CreateFull(Integer(Args.Values[0]));
+    if (Args.Count = 1) and VarIsStr(Args.Values[0]) then begin
       for i := Low(Files) to High(Files) do
-        if Files[i].LoadOrderFileID = aLoadOrderFileID then begin
+        if Files[i].LoadOrderFileID.ToString = Args.Values[0] then begin
           Value := Files[i];
           Break;
         end;


### PR DESCRIPTION
Takes format expected as result from GetLoadOrderFileID.

This means if you want a module showing `[FE 001]` then you pass 'FE 001' if you want '[08]' you pass '08'. If you have a simple integer value like 8 then you would use IntToHex programatically.