### PR TITLE
SF1 Freelanes updates

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -148,7 +148,7 @@ type
   end;
 
 const
-  wbConditionFunctions : array[0..609] of TConditionFunction = (
+  wbConditionFunctions : array[0..610] of TConditionFunction = (
     (Index:   0; Name: 'GetWantBlocking'),                                                                                                                  //   0
     (Index:   1; Name: 'GetDistance'; ParamType1: ptReference),                                                                                       //   1
     (Index:   5; Name: 'GetLocked'),                                                                                                                        //   2
@@ -757,8 +757,9 @@ const
     (Index: 958; Name: 'ShipReactorHasClassKeyword'; ParamType1: ptKeyword; Desc: 'Check if the reactor of the supplied ship has the provided reactor class keyword (keywords in ShipClassOrder form list)'),                                                                                //   605
     (Index: 960; Name: 'EPIsResistanceActorValue'; ParamType1: ptActorValue; Desc: 'Is a specific resistance actor value passed into this check?'),                                                                                //   606
     (Index: 961; Name: 'GetGamePlayOptionCurrentValue'; ParamType1: ptGamePlayOption; Desc: 'Gets the current value of a Gameplay Option form.'),                                                                                //   607
-    (Index: 965; Name: 'IsInVehicle';),
-    (Index: 966; Name: 'AreVehiclesUnlocked';)
+    (Index: 965; Name: 'IsInVehicle'; Desc: 'Is this ref in a vehicle?'),
+    (Index: 966; Name: 'AreVehiclesUnlocked'; Desc: 'Has the player unlocked vehicles?'),
+    (Index: 967; Name: 'IsLevelGreaterThanGameplayOption'; ParamType1: ptGamePlayOption; Desc: 'Is level of Refr greater than passed gameplay option value?')
   );
 
 function wbConditionDescFromIndex(aIndex: Integer): PConditionFunction;
@@ -1674,6 +1675,8 @@ begin
     40: Result := 4; // Spawn Hazard
     45: Result := 9; // Damage Type
     46: Result := 6; // Immunity
+    54: Result := 10; // TrackDamage
+    55: Result := 11; // GravWielder
   end;
 end;
 
@@ -3096,7 +3099,8 @@ begin
     {250} 'Mod Armor Resistance',
     {251} 'Mod Ship Linear Acceleration',
     {252} 'Mod Final Player Ground Combat Damage',
-    {253} 'Mod Final Player Ship Combat Damage'
+    {253} 'Mod Final Player Ship Combat Damage',
+    {254} 'Mod Richochet Chance Spaceship'
   ]);
 
   var wbEquipType := wbFlags([
@@ -5533,8 +5537,18 @@ begin
         ]),
         //BGSAdaptiveTriggerData_Component
         wbRStruct('Component Data - Adaptive Trigger', [
-          wbUnknown(WFIR),
-          wbUnknown(WAIM)
+          wbStruct(WFIR, 'ADS Effect', [
+            wbUnused(2),
+            wbInteger('ADS Effect Start Poisiton', itU8),
+            wbInteger('ADS Effect End Poisiton', itU8),
+            wbInteger('ADS Effect Strength', itU8)
+          ]),
+          wbStruct(WAIM, 'Fire Effect', [
+            wbUnused(2),
+            wbInteger('Fire Effect Start Poisiton', itU8),
+            wbInteger('Fire Effect End Poisiton', itU8),
+            wbInteger('Fire Effect Strength', itU8)
+          ])
         ]),
         //BGSAddToInventoryOnDestroy_Component
         wbRStructSK([0],'Component Data - Add to inventory on destroy', [
@@ -5588,7 +5602,7 @@ begin
           wbArray(DCSD, 'Display Case Slot Snap Templates', // DO NOT SORT. The later DCED exclusivity uses the same order as here
             wbStruct('Template Slot', [
               wbFormIDCk('Display Filter', [FLST]),
-              wbFormIDCk('Exclusion Filter Keyword', [NULL, KYWD]),
+              wbFormIDCk('Exclusion Filter Keyword', [NULL, FLST, KYWD]),
               wbInteger('Display Slot', itU32),
               wbInteger('Number', itU32)
             ]).SetSummaryKey([0,2,1,3])
@@ -5666,7 +5680,9 @@ begin
         ]),
         //BGSQualityUpgrade_Component
         wbRStruct('Component Data - Quality Upgrade', [
-          wbUnknown(QUPA)
+          wbArray(QUPA, 'Item Specific Mod',
+            wbFormIDCK('Item Specific Mod', [OMOD])
+          )
         ]),
         //BGSSoundTag_Component
         wbRStructSK([0], 'Component Data - Sound Tag', [
@@ -6709,6 +6725,7 @@ begin
            {14} 'Multiply 1 + Actor Value Mult', // EPFT=2
            {15} 'Set Text', // EPFT=7
            {16} 'Legendary Magic Effect Event' // EPFT=9
+           {17} 'Select Aimed Spell' // EPFT=5
           ])),
           wbInteger('Perk Condition Tab Count', itU8, nil, cpIgnore)
         ])
@@ -7312,7 +7329,9 @@ begin
     {50} 'Capacity Value Modifier',
     {51} 'Reset Flora',
     {52} 'Drop Resources',
-    {53} 'Antigravity'
+    {53} 'Antigravity',
+    {54} 'Track Damage',
+    {55} 'Gravity Wielder'
   ])).SetAfterSet(wbMGEFArchtypeAfterSet);
 
   var wbMGEFData :=
@@ -7327,7 +7346,9 @@ begin
               wbFormIDCk('Assoc. Item 1', [DMGT, NULL]),        // immunity
               wbFormIDCk('Assoc. Item 1', [ENCH, NULL]),        // enhance weapon
               wbFormIDCk('Assoc. Item 2', [KYWD, NULL]),        // peak modifier
-              wbFormIDCk('Assoc. Item 1', [DMGT, NULL])         // damage type
+              wbFormIDCk('Assoc. Item 1', [DMGT, NULL]),        // damage type
+              wbFormIDCk('Assoc. Item 1', [TDED, NULL]),        // track damage
+              wbFormIDCk('Assoc. Item 1', [GWED, NULL])         // gravity wielder
             ]),
       {  4} wbActorValue('Magic Skill'),
       {  8} wbFormIDCk('Casting Art', [NULL, ARTO]),
@@ -8162,7 +8183,9 @@ begin
       5, 'Slayton Aerospace',
       6, 'United Colonies',
       7, 'Crimson Fleet',
-      9, 'House Varuun'
+      8, 'House Varuun',
+      9, 'Ship Upgrade',
+      10, 'Terran Armada'
     ]);
 
   var wbBIOMMaskNameStringEnum := wbStringEnum([
@@ -8753,8 +8776,9 @@ begin
           7, 'Allow Grav Jump',
           9, 'Suppress Discovery',
          10, 'Use Accurate Z-Height',
-         11, 'Limit Map Visibility To Compass Range'
-        ], False, 12))
+         11, 'Limit Map Visibility To Compass Range',
+         12, 'Must Cruise to First'
+        ], False, 13))
       ).SetRequired
        .IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbFULLReq,
@@ -12356,8 +12380,26 @@ begin
     ], cpNormal, True)
   ]);
 
-  wbRecord(GWED, 'Gravity Welder Effect Data', [
+  wbRecord(GWED, 'Gravity Wielder Effect Data',
+    wbFlags(wbFlagsList([
+    2, 'Non-Playable',
+    4, 'Ground Piece',
+    9, 'Hidden From Local Map',
+    11, 'Used As Platform',
+    19, 'Has Currents',
+    26, 'Navmesh - Filter',
+    27, 'Navmesh - Bounding Box',
+    28, 'Navmesh - Only Cut',
+    29, 'Navmesh - Ignore Erosion/Child Can Use',
+    30, 'Navmesh - Ground'
+    ])).SetFlagHasDontShow(26, wbFlagNavmeshFilterDontShow)
+    .SetFlagHasDontShow(27, wbFlagNavmeshBoundingBoxDontShow)
+    .SetFlagHasDontShow(28, wbFlagNavmeshOnlyCutDontShow)
+    .SetFlagHasDontShow(29, wbFlagNavmeshIgnoreErosionDontShow)
+    .SetFlagHasDontShow(30, wbFlagNavmeshGroundDontShow), [
     wbEDID,
+    wbVMAD,
+    wbBaseFormComponents,
     wbReflection(REFL)
   ]);
 
@@ -15322,7 +15364,10 @@ begin
         //61-65
         66, 'RangingWithPlayer',
         67, 'FollowPlayer',
-        //68-80
+        //68-73
+        74, 'Find',
+        75, 'Acquire',
+        //76-80
         81, 'DefaultCombatMasterTemplate',
        134, 'Master_ShootTarget',
        145, 'ShootTarget'
@@ -15526,7 +15571,7 @@ begin
       wbConditions,
       wbActivityTracker,
       wbDESC.SetRequired,
-      wbUnknown(PRUC),
+      wbInteger(PRUC, 'Quantum Essence Upgrade Cost', itU32),
       wbEmpty(PRRF, 'End Marker').SetRequired
     ], [], cpNormal, True),
     wbRArray('Bonus Perks', wbFormIDCk(RNAM, 'Perk', [PERK]))
@@ -17749,6 +17794,22 @@ begin
   ]);
 
   wbRecord(TDED, 'Track Damage Effect Data', [
+    wbFlags(wbFlagsList([
+      2, 'Non-Playable',
+      4, 'Ground Piece',
+      9, 'Hidden From Local Map',
+      11, 'Used As Platform',
+      19, 'Has Currents',
+      26, 'Navmesh - Filter',
+      27, 'Navmesh - Bounding Box',
+      28, 'Navmesh - Only Cut',
+      29, 'Navmesh - Ignore Erosion/Child Can Use',
+      30, 'Navmesh - Ground'
+      ])).SetFlagHasDontShow(26, wbFlagNavmeshFilterDontShow)
+        .SetFlagHasDontShow(27, wbFlagNavmeshBoundingBoxDontShow)
+        .SetFlagHasDontShow(28, wbFlagNavmeshOnlyCutDontShow)
+        .SetFlagHasDontShow(29, wbFlagNavmeshIgnoreErosionDontShow)
+        .SetFlagHasDontShow(30, wbFlagNavmeshGroundDontShow), [
     wbEDID,
     wbReflection(REFL)
   ]);


### PR DESCRIPTION
Freelanes:
- Added 'IsLevelGreaterThanGameplayOption' condition
- Added 'Mod Richochet Chance Spaceship' perk entry point
- Defined 'BGSAdaptiveTriggerData_Component' and 'BGSQualityUpgrade_Component'
- DSCD \ Allowed 'Exclusion Filter Keyword' to accept FLST parameters
- Added 'Select Aimed Spell' perk entry function type
- PERK \ PRUC \ Defined as 'Quantum Essence Upgrade Cost', a itU32
- PACK \ XNAM \ Added Find and Acquire package groups
- LGDI \ Defined MNAM, FNAM, KNAM, LNAM, Conditions, GNAM, HNAM, INAM, and JNAM
- Added 'Ship Upgrade' and 'Terran Armada' terminal backgrounds
- REFR \ FNAM \ Added 'Must Cruise to First' flag.