### PR TITLE
Strip plugin extension from user input in AddNewFile

### DIFF
--- a/xEdit/xeMainForm.pas
+++ b/xEdit/xeMainForm.pas
@@ -1924,8 +1924,13 @@ begin
   Result := False;
   s := '';
   if InputQuery('New Module File', 'Filename without extension:', s) then begin
+    s := Trim(s);
     if s = '' then
       Exit;
+    if SameText(ExtractFileExt(s), '.esp') or
+       SameText(ExtractFileExt(s), '.esm') or
+       SameText(ExtractFileExt(s), '.esl') then
+      s := ChangeFileExt(s, '');
     if aIsLight then
       s := s + '.esl'
     else
@@ -1946,6 +1951,10 @@ begin
     s := Trim(s);
     if s = '' then
       Exit;
+    if SameText(ExtractFileExt(s), '.esp') or
+       SameText(ExtractFileExt(s), '.esm') or
+       SameText(ExtractFileExt(s), '.esl') then
+      s := ChangeFileExt(s, '');
     s := s + aTemplate.miExtension.ToString;
     aFile := AddNewFileName(s, aTemplate);
     if Assigned(aFile) and wbAlwaysLoadGameMaster then


### PR DESCRIPTION
If the user types `MyMod.esp` despite the dialog saying *Filename without extension*, the extension was appended verbatim, producing `MyMod.esp.esp`. This strips `.esp`, `.esm`, or `.esl` from the input before appending the correct extension.

Also adds the missing `Trim()` call to the legacy `AddNewFile` overload (`aIsLight`/`aIsMedium`), which the template overload already had.

**Changed:** `xEdit/xeMainForm.pas` — both `AddNewFile` overloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)